### PR TITLE
Refactor

### DIFF
--- a/src/99-valve-index-reboot.rules
+++ b/src/99-valve-index-reboot.rules
@@ -1,6 +1,6 @@
 # Valve Index HMD: fix blank EDID
-# Works around blank EDID bug that makes the kernel see the HMD as a 640x480 monitor.
-# Sends a HID reboot command once per boot when the device is enumerated.
-# /tmp is cleared on boot so the flag resets automatically.
+# Trigger systemd service on device add.
 
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2300", ACTION=="add", RUN+="/bin/sh -c '(sleep 2; test -f /tmp/.valve-index-rebooted || { printf \"\\x16\\x01\" | cat - /dev/zero | head -c 64 > /dev/%k && touch /tmp/.valve-index-rebooted; }) &'"
+ACTION=="add", SUBSYSTEM=="hidraw", KERNEL=="hidraw*", \
+  ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2300", \
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="valve-index-hid-reboot@%k.service"

--- a/src/install.sh
+++ b/src/install.sh
@@ -43,6 +43,10 @@ die()   { echo -e "${RED}[✗]${NC} $*" >&2; exit 1; }
 # Helpers
 # ---------------------------------------------------------------------------
 SUDO=""
+_TMP_FILES=()    # tracks temp files downloaded by find_or_download
+_cleanup_tmp() { [[ ${#_TMP_FILES[@]} -gt 0 ]] && rm -f "${_TMP_FILES[@]}"; }
+trap '_cleanup_tmp' EXIT
+
 setup_sudo() {
     if [[ $EUID -eq 0 ]]; then
         SUDO=""
@@ -78,6 +82,7 @@ find_or_download() {
     warn "File $filename not found locally, downloading from GitHub…" >&2
     local tmp_file
     tmp_file="$(mktemp "/tmp/${filename}.XXXXXX")"
+    _TMP_FILES+=("$tmp_file")
 
     if command -v curl &>/dev/null; then
         curl -fsSL "$url" -o "$tmp_file" || die "Failed to download $filename."

--- a/src/install.sh
+++ b/src/install.sh
@@ -7,8 +7,21 @@ set -euo pipefail
 # Config
 # ---------------------------------------------------------------------------
 RULE_FILE="99-valve-index-reboot.rules"
+SCRIPT_FILE="valve-index-hid-reboot.sh"
+SERVICE_FILE="valve-index-hid-reboot@.service"
+HOOK_FILE="valve-index-hid-reboot"
+
 RULE_DST="/etc/udev/rules.d/$RULE_FILE"
-RULE_RAW_URL="https://raw.githubusercontent.com/MiguVT/fixvr/main/src/$RULE_FILE"
+SCRIPT_DST="/usr/local/sbin/$SCRIPT_FILE"
+SERVICE_DST="/etc/systemd/system/$SERVICE_FILE"
+HOOK_DST="/etc/systemd/system-sleep/$HOOK_FILE"   # Universal, distro-agnostic
+
+RAW_BASE="https://raw.githubusercontent.com/MiguVT/fixvr/main/src"
+RULE_RAW_URL="$RAW_BASE/$RULE_FILE"
+SCRIPT_RAW_URL="$RAW_BASE/$SCRIPT_FILE"
+SERVICE_RAW_URL="$RAW_BASE/$SERVICE_FILE"
+HOOK_RAW_URL="$RAW_BASE/$HOOK_FILE"
+
 AUR_PKG="fixvr-git"
 
 # ---------------------------------------------------------------------------
@@ -40,17 +53,19 @@ setup_sudo() {
     fi
 }
 
-# Locate the rule file relative to this script (works when called from anywhere)
-# Falls back to downloading from GitHub when run via curl | bash
-find_rule_file() {
+# Locate a file relative to this script, fallback to download from GitHub
+find_or_download() {
+    local filename="$1"
+    local url="$2"
+
     local script_dir
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
     local candidates=(
-        "$script_dir/$RULE_FILE"               # running from src/
-        "$script_dir/../src/$RULE_FILE"        # running from repo root
-        "$(pwd)/src/$RULE_FILE"                # cwd is repo root
-        "$(pwd)/$RULE_FILE"                    # cwd is src/
+        "$script_dir/$filename"           # running from src/
+        "$script_dir/../src/$filename"    # running from repo root
+        "$(pwd)/src/$filename"            # cwd is repo root
+        "$(pwd)/$filename"                # cwd is src/
     )
 
     for f in "${candidates[@]}"; do
@@ -60,21 +75,20 @@ find_rule_file() {
         fi
     done
 
-    # Not found locally (e.g. run via curl | bash) — download from GitHub
-    warn "Rule file not found locally, downloading from GitHub…" >&2
-    local tmp_rule
-    tmp_rule="$(mktemp "/tmp/${RULE_FILE}.XXXXXX")"
+    warn "File $filename not found locally, downloading from GitHub…" >&2
+    local tmp_file
+    tmp_file="$(mktemp "/tmp/${filename}.XXXXXX")"
 
     if command -v curl &>/dev/null; then
-        curl -fsSL "$RULE_RAW_URL" -o "$tmp_rule" || die "Failed to download rule file from GitHub."
+        curl -fsSL "$url" -o "$tmp_file" || die "Failed to download $filename."
     elif command -v wget &>/dev/null; then
-        wget -qO "$tmp_rule" "$RULE_RAW_URL" || die "Failed to download rule file from GitHub."
+        wget -qO "$tmp_file" "$url" || die "Failed to download $filename."
     else
-        die "Rule file not found locally and neither curl nor wget is available."
+        die "Neither curl nor wget is available to download $filename."
     fi
 
-    [[ -s "$tmp_rule" ]] || die "Downloaded rule file is empty."
-    printf '%s\n' "$tmp_rule"
+    [[ -s "$tmp_file" ]] || die "Downloaded $filename is empty."
+    printf '%s\n' "$tmp_file"
 }
 
 # ---------------------------------------------------------------------------
@@ -164,12 +178,12 @@ install_aur() {
 
     info "Using AUR helper: $aur_helper"
     step "Installing $AUR_PKG…"
-    
+
     # When piped via `curl | bash`, standard input is hijacked.
     # We must explicitly reconnect stdin to the terminal so the user can interact.
     "$aur_helper" -S "$AUR_PKG" </dev/tty
 
-    info "Done! The udev rule was installed via the AUR package."
+    info "Done! The files were installed via the AUR package."
 }
 
 # ---------------------------------------------------------------------------
@@ -178,19 +192,30 @@ install_aur() {
 install_manual() {
     setup_sudo
 
-    local rule_src
-    rule_src="$(find_rule_file)"
-    [[ -f "$rule_src" ]] || die "Rule file not found: $rule_src"
-    step "Rule file found: $rule_src"
+    local rule_src script_src service_src hook_src
+    rule_src="$(find_or_download "$RULE_FILE" "$RULE_RAW_URL")"
+    script_src="$(find_or_download "$SCRIPT_FILE" "$SCRIPT_RAW_URL")"
+    service_src="$(find_or_download "$SERVICE_FILE" "$SERVICE_RAW_URL")"
+    hook_src="$(find_or_download "$HOOK_FILE" "$HOOK_RAW_URL")"
 
     step "Installing udev rule to $RULE_DST…"
     $SUDO install -m 644 -o root -g root "$rule_src" "$RULE_DST"
 
-    step "Reloading udev rules…"
+    step "Installing script to $SCRIPT_DST…"
+    $SUDO install -m 755 -o root -g root "$script_src" "$SCRIPT_DST"
+
+    step "Installing systemd service to $SERVICE_DST…"
+    $SUDO install -m 644 -o root -g root "$service_src" "$SERVICE_DST"
+
+    step "Installing systemd sleep hook to $HOOK_DST…"
+    $SUDO install -m 755 -o root -g root "$hook_src" "$HOOK_DST"
+
+    step "Reloading systemd and udev…"
+    $SUDO systemctl daemon-reload
     $SUDO udevadm control --reload-rules
     $SUDO udevadm trigger --action=add --subsystem-match=hidraw
 
-    info "Done! Reconnect your Valve Index to apply the fix."
+    info "Done! Reconnect your Valve Index or resume from sleep to apply the fix."
 }
 
 # ---------------------------------------------------------------------------
@@ -208,10 +233,10 @@ echo
 if is_nixos; then
     warn "NixOS detected. Manual file installation won't persist across rebuilds."
     echo
-    echo -e "  Add the udev rule declaratively in your NixOS configuration instead."
+    echo -e "  Add the files declaratively in your NixOS configuration instead."
     echo -e "  See: ${CYAN}https://fixvr.miguvt.com/install#nixos${NC}"
     echo
-    read -rp "  Install manually to /etc/udev/rules.d/ anyway? [y/N] " yn </dev/tty
+    read -rp "  Install manually anyway? [y/N] " yn </dev/tty
     echo
     case "$yn" in
         [Yy]*) install_manual ;;

--- a/src/install.sh
+++ b/src/install.sh
@@ -197,6 +197,10 @@ install_aur() {
 install_manual() {
     setup_sudo
 
+    if ! command -v systemctl &>/dev/null; then
+        die "systemd is required for this fix (the udev rule uses SYSTEMD_WANTS).\n  Please use a systemd-based distro or install the files manually."
+    fi
+
     local rule_src script_src service_src hook_src
     rule_src="$(find_or_download "$RULE_FILE" "$RULE_RAW_URL")"
     script_src="$(find_or_download "$SCRIPT_FILE" "$SCRIPT_RAW_URL")"

--- a/src/valve-index-hid-reboot
+++ b/src/valve-index-hid-reboot
@@ -1,0 +1,8 @@
+#!/bin/sh
+case "$1" in
+  post)
+    rm -f /run/.valve-index-rebooted
+    sleep 2
+    /usr/local/sbin/valve-index-hid-reboot.sh
+    ;;
+esac

--- a/src/valve-index-hid-reboot.sh
+++ b/src/valve-index-hid-reboot.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+VID="28de"
+PID="2300"
+FLAG="/run/.valve-index-rebooted"
+
+for dev in /dev/hidraw*; do
+  [ -e "$dev" ] || continue
+  sys="/sys/class/hidraw/$(basename "$dev")/device"
+
+  v="$(cat "$sys/idVendor" 2>/dev/null || true)"
+  p="$(cat "$sys/idProduct" 2>/dev/null || true)"
+  v="${v#0x}"
+  p="${p#0x}"
+
+  if [ "$v" = "$VID" ] && [ "$p" = "$PID" ]; then
+    printf '\x16\x01' | cat - /dev/zero | head -c 64 > "$dev" || true
+    : > "$FLAG"
+    exit 0
+  fi
+done
+
+exit 0

--- a/src/valve-index-hid-reboot.sh
+++ b/src/valve-index-hid-reboot.sh
@@ -15,9 +15,13 @@ for dev in /dev/hidraw*; do
   p="${p#0x}"
 
   if [ "$v" = "$VID" ] && [ "$p" = "$PID" ]; then
-    printf '\x16\x01' | cat - /dev/zero | head -c 64 > "$dev" || true
-    : > "$FLAG"
-    exit 0
+    if printf '\x16\x01' | cat - /dev/zero | head -c 64 > "$dev"; then
+      : > "$FLAG"
+      exit 0
+    else
+      echo "Failed to write reboot command to $dev" >&2
+      exit 1
+    fi
   fi
 done
 

--- a/src/valve-index-hid-reboot@.service
+++ b/src/valve-index-hid-reboot@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Valve Index HID reboot for /dev/%I
+After=systemd-udevd.service
+ConditionPathExists=/dev/%I
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'sleep 2; if ! test -f /run/.valve-index-rebooted; then /usr/local/sbin/valve-index-hid-reboot.sh; fi'

--- a/src/valve-index-hid-reboot@.service
+++ b/src/valve-index-hid-reboot@.service
@@ -5,4 +5,4 @@ ConditionPathExists=/dev/%I
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'sleep 2; if ! test -f /run/.valve-index-rebooted; then /usr/local/sbin/valve-index-hid-reboot.sh; fi'
+ExecStart=/usr/bin/flock /run/valve-index-hid-reboot.lock /bin/sh -c 'sleep 2; if ! test -f /run/.valve-index-rebooted; then /usr/local/sbin/valve-index-hid-reboot.sh; fi'


### PR DESCRIPTION
This pull request refactors the Valve Index HID reboot fix to use systemd services and hooks instead of ad-hoc shell commands in udev rules. The new approach improves maintainability, reliability, and cross-distro compatibility. It introduces dedicated scripts and service files, and updates the installer to handle these files. The most important changes are:

**Migration to systemd-based reboot logic:**
* The udev rule (`99-valve-index-reboot.rules`) now triggers a systemd service (`valve-index-hid-reboot@.service`) on device add, replacing the previous inline shell command.
* Added a systemd unit file (`valve-index-hid-reboot@.service`) that runs the reboot script safely, only if needed.
* Introduced a dedicated reboot script (`valve-index-hid-reboot.sh`) to encapsulate the device reset logic, improving clarity and testability.
* Added a systemd sleep hook (`valve-index-hid-reboot`) to ensure the device is reset after resume from sleep.

**Installer improvements:**
* The installer (`install.sh`) now installs all required files (udev rule, script, service, and sleep hook), downloading them as needed, and reloads both systemd and udev to apply changes. [[1]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17R10-R24) [[2]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L43-R68) [[3]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L63-R91) [[4]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L181-R218)
* Improved file lookup and download logic in the installer, making it more robust and flexible. [[1]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L43-R68) [[2]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L63-R91)

**Documentation and messaging:**
* Updated user messages to clarify that multiple files are now installed, and that the fix will apply both on device reconnect and resume from sleep. [[1]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L172-R186) [[2]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L211-R239) [[3]](diffhunk://#diff-2c29a3d3d0c531f931fbdd88ab9a910b2c99db5a471af2f8b161874870149c17L181-R218)